### PR TITLE
fix: array of enum values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-class-validator-type-match",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-class-validator-type-match",
-      "version": "3.1.3",
+      "version": "3.1.4",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": "^8.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-class-validator-type-match",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "ESLint plugin to ensure class-validator decorators match TypeScript type annotations",
   "keywords": [
     "eslint",


### PR DESCRIPTION
This pull request updates the `eslint-plugin-class-validator-type-match` package to improve support for class-validator enum subset patterns and refines internal type checking logic. The main focus is ensuring that the plugin correctly recognizes when an `@IsEnum` decorator argument is an array or tuple of enum values, which is a valid pattern in class-validator for restricting validation to a subset of enum values.

**Enum subset support improvements:**

* Added a new utility function `isEnumArgumentArraySubset` in `src/utils/type-helpers.util.ts` to detect if the argument to `@IsEnum` is an array or tuple type, allowing subset validation patterns.
* Updated the rule logic in `src/rules/decorator-type-match.ts` to use `isEnumArgumentArraySubset` and skip enum type mismatch reporting for array/tuple arguments.
* Imported `isEnumArgumentArraySubset` into the rule file for use in validation logic.

**TypeScript parser services usage:**

* Changed usage of parser services in `src/rules/decorator-type-match.ts` to reference `context.sourceCode.parserServices` for improved reliability and compatibility.

**Package version update:**

* Bumped the package version in `package.json` from `3.1.3` to `3.1.4` to reflect the new functionality and fixes.